### PR TITLE
Remove duplicate appengine dependency in pom.

### DIFF
--- a/capstone-app/pom.xml
+++ b/capstone-app/pom.xml
@@ -39,11 +39,6 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>


### PR DESCRIPTION
Prevents warning on startup:

```
[WARNING] Some problems were encountered while building the effective model for com.google.sps:capstone:war:1
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.google.appengine:appengine-api-1.0-sdk:jar -> duplicate declaration of version 1.9.59 @ line 41, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
```